### PR TITLE
Add std_msgs to package.xml and CMakeLists.txt in the pid_library package for compatibility with ROS 2 Iron

### DIFF
--- a/pid_library/CMakeLists.txt
+++ b/pid_library/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
 
 add_library(pid_library src/pid_library.cpp)
 target_link_libraries(pid_library ${rclcpp_LIBRARIES})
@@ -17,7 +18,7 @@ target_include_directories(pid_library PUBLIC
   ${rclcpp_INCLUDE_DIRS}
 )
 
-ament_target_dependencies(pid_library rclcpp)
+ament_target_dependencies(pid_library rclcpp std_msgs)
 ament_export_dependencies(rclcpp)
 ament_export_targets(export_pid_library HAS_LIBRARY_TARGET)
 

--- a/pid_library/package.xml
+++ b/pid_library/package.xml
@@ -8,6 +8,8 @@
   <license>TODO: License declaration</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  
+  <depend>std_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Add std_msgs to package.xml and CMakeLists.txt in the pid_library package for compatibility with ROS 2 Iron

This package would not build on ROS 2 Iron since std_msgs was not included in CMakeLists.txt and package.xml